### PR TITLE
Add flutter build/test workflow

### DIFF
--- a/.github/workflows/flutter_build_test.yml
+++ b/.github/workflows/flutter_build_test.yml
@@ -1,0 +1,22 @@
+name: Flutter Build Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: stable
+          channel: stable
+      - name: Install dependencies
+        run: flutter pub get
+      - name: Run tests
+        run: flutter test
+      - name: Build APK
+        run: flutter build apk --debug


### PR DESCRIPTION
## Summary
- add CI workflow to build and test Flutter app on pushes and PRs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdff7941c832e8c8ed64f7c9af1a9