### PR TITLE
Improve Todo tab UI

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -83,12 +83,68 @@ class DashboardPage extends StatelessWidget {
   }
 }
 
-class TodoPage extends StatelessWidget {
+class TodoPage extends StatefulWidget {
   const TodoPage({super.key});
 
   @override
+  State<TodoPage> createState() => _TodoPageState();
+}
+
+class _TodoPageState extends State<TodoPage> {
+  final TextEditingController _controller = TextEditingController();
+  final List<String> _todos = [];
+
+  void _addTodo() {
+    final text = _controller.text.trim();
+    if (text.isNotEmpty) {
+      setState(() {
+        _todos.add(text);
+        _controller.clear();
+      });
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Text('Add Todo Page');
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  decoration: const InputDecoration(
+                    labelText: 'Add a todo',
+                  ),
+                  onSubmitted: (_) => _addTodo(),
+                ),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: _addTodo,
+                child: const Text('Add'),
+              )
+            ],
+          ),
+          const SizedBox(height: 16),
+          Expanded(
+            child: _todos.isEmpty
+                ? const Center(child: Text('No todos yet'))
+                : ListView.builder(
+                    itemCount: _todos.length,
+                    itemBuilder: (context, index) {
+                      return ListTile(
+                        leading: const Icon(Icons.check_box_outline_blank),
+                        title: Text(_todos[index]),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
   }
 }
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,9 +9,17 @@ void main() {
     // Dashboard page should be visible initially
     expect(find.text('Dashboard Page'), findsOneWidget);
 
-    // Tap the Todo tab and verify
+    // Tap the Todo tab and verify initial state
     await tester.tap(find.text('Todo'));
     await tester.pumpAndSettle();
-    expect(find.text('Add Todo Page'), findsOneWidget);
+    expect(find.text('No todos yet'), findsOneWidget);
+
+    // Add a todo item
+    await tester.enterText(find.byType(TextField), 'Buy milk');
+    await tester.tap(find.text('Add'));
+    await tester.pump();
+
+    // Verify the added item appears
+    expect(find.text('Buy milk'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- redesign Todo tab into a stateful todo list
- test adding a todo item

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe83a5974832e8af773d110cbb9d5